### PR TITLE
Fix an issue with processing written-off dates.

### DIFF
--- a/Entity/Invoice.php
+++ b/Entity/Invoice.php
@@ -239,7 +239,7 @@ class Invoice extends AbstractEntity
     /**
      * @var \DateTime
      * @Groups({"get","update","post"})
-     * @Type("DateTime<'Y-m-d\TH:i:sO'>")
+     * @Type("DateTime<'Y-m-d'>")
      */
     protected $writtenOffDate;
 


### PR DESCRIPTION
Written-off dates are `Y-m-d`, not `Y-m-d\TH:i:sO`. See https://dev.freeagent.com/docs/invoices for more details.